### PR TITLE
perf: optimize Docker build by reusing node_modules from build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,9 @@ RUN npm ci
 COPY --chown=node:node . ./
 RUN npm run build
 
+# Prune dev dependencies after build
+RUN npm prune --omit=dev
+
 FROM base AS production
 
 RUN apt-get update && \
@@ -27,9 +30,10 @@ COPY --chown=node:node package.json package-lock.json entrypoint.sh ./
 RUN chmod +x entrypoint.sh && sed -i 's/\r$//' entrypoint.sh
 
 USER node
-RUN npm ci
 
-COPY --from=production_buildstage /home/node/app/dist /home/node/app/dist
+# Copy pruned node_modules and dist from build stage instead of running npm ci again
+COPY --from=production_buildstage --chown=node:node /home/node/app/node_modules /home/node/app/node_modules
+COPY --from=production_buildstage --chown=node:node /home/node/app/dist /home/node/app/dist
 
 CMD ["./entrypoint.sh"]
 


### PR DESCRIPTION
Some more Dockerfile adjustments.

## Summary
- Add `npm prune --omit=dev` after build to remove dev dependencies
- Copy pruned node_modules from build stage instead of running `npm ci` again
- Reduces image size by ~12MB and removes 573 dev packages from production

## Changes
- Build stage now prunes dev dependencies after `npm run build`
- Production stage copies pre-pruned `node_modules` instead of running `npm ci` again
- Faster builds (one less `npm ci`) and smaller final image

## Testing
Tested locally with PostgreSQL:

| Test | Endpoint | Result |
|------|----------|--------|
| Health | `GET /health` | ✅ |
| Create scene | `POST /scenes` | ✅ |
| Get scene | `GET /scenes/:id` | ✅ |
| Create room | `PUT /rooms/:id` | ✅ |
| Get room | `GET /rooms/:id` | ✅ |
| Create file | `PUT /files/:id` | ✅ |
| Get file | `GET /files/:id` | ✅ |
| Update timestamp | `PATCH /files/:id/timestamp` | ✅ |

## Image size comparison
| Version | Size |
|---------|------|
| Before | 466 MB |
| After | 454 MB |